### PR TITLE
python-gssapi 1.8.3: rebuild against libkrb5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
-
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,7 +3,8 @@ setlocal EnableDelayedExpansion
 echo on
 
 set GSSAPI_LINKER_ARGS=-lgssapi64
-set GSSAPI_COMPILER_ARGS=-DMS_WIN64
+set GSSAPI_COMPILER_ARGS=-DMS_WIN64 -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0601
 set GSSAPI_MAIN_LIB=%LIBRARY_BIN%\gssapi64.dll
+set GSSAPI_SUPPORT_DETECT=false
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,8 +3,7 @@ setlocal EnableDelayedExpansion
 echo on
 
 set GSSAPI_LINKER_ARGS=-lgssapi64
-set GSSAPI_COMPILER_ARGS=-DMS_WIN64 -DWIN32_LEAN_AND_MEAN -D_WIN32_WINNT=0x0601
+set GSSAPI_COMPILER_ARGS=-DMS_WIN64
 set GSSAPI_MAIN_LIB=%LIBRARY_BIN%\gssapi64.dll
-set GSSAPI_SUPPORT_DETECT=false
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - fix_path.patch        # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
 {% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi\\tests\\test_high_level.py --ignore=gssapi\\tests\\test_raw.py" %}  # [win]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%\gssapi\tests\test_high_level.py --ignore=%SP_DIR%\gssapi\tests\test_raw.py" %}  # [win]
 
 test:
   imports:
@@ -69,7 +69,7 @@ test:
     - pip install k5test
     - pytest -v gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest -v gssapi/tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest --pyargs gssapi.tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,13 +28,18 @@ requirements:
   host:
     - python
     - cython >=0.29.29,<4.0.0a0
-    - krb5 {{ krb5 }}
+    # libkrb5 1.21.3 (libraries and headers) fails on Windows with an error: "C2065: 'gss_key_value_set_desc': undeclared identifier"
+    # but krb5 (plus executables) works fine.
+    - krb5 {{ krb5 }}     # [win]
+    - libkrb5 {{ krb5 }}  # [unix]
     - pip
     - setuptools >=40.6.0
     - wheel
   run:
     - python
     - decorator
+    # libkrb5 provides gssapi64.dll on Windows
+    - libkrb5  # [win]
 
 test:
   imports:
@@ -45,6 +50,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -c "import gssapi; print(gssapi.__version__)"
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,9 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_basic_init_default_ctx or test_bad_channel_binding_raises_error or test_basic_accept_context or test_basic_accept_context_no_acceptor_creds or test_channel_bindings" %}
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
+{% set tests_to_ignore = "" %}
+{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py" %}        # [win]
+
 test:
   imports:
     - gssapi
@@ -64,9 +67,9 @@ test:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
     - pip install k5test
+    - pytest -v gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})"  # [unix]
-    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})" --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py  # [win]
+    - pytest -v gssapi/tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ test:
     - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
     # Remove test files
-    - del %SP_DIR%\\gssapi\\tests\\test_raw.py %SP_DIR%\\gssapi\\tests\\test_high_level.py
+    - del %SP_DIR%\\gssapi\\tests\\test_raw.py %SP_DIR%\\gssapi\\tests\\test_high_level.py  # [win]
     - python -m pytest -v -k "not ({{ tests_to_skip }})" %SP_DIR%/gssapi/tests # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,21 +54,19 @@ test:
     - gssapi
     - gssapi.raw
     - gssapi.raw._enum_extensions
-  source_files:
-    - gssapi/tests
+  source_files:      # [unix]
+    - gssapi/tests   # [unix]
   requires:
     - pip
-    - pytest
-    - parameterized
+    - pytest         # [unix]
+    - parameterized  # [unix]
   commands:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
-    - pip install k5test
-    - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
+    - pip install k5test                                               # [unix]
+    - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"  # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    # Remove test files
-    - del %SP_DIR%\\gssapi\\tests\\test_raw.py %SP_DIR%\\gssapi\\tests\\test_high_level.py  # [win]
-    - python -m pytest -v -k "not ({{ tests_to_skip }})" %SP_DIR%/gssapi/tests # [win]
+    # Skip tests on Windows because k5test gets files from %SP_DIR% and not from source files.
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gssapi" %}
-{% set version = "1.9.0" %}
+{% set version = "1.8.3" %}
 
 package:
   name: python-gssapi
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe
+  sha256: aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0
   patches:                  # [win or osx]
     - 0001-fix-setup.patch  # [osx]
     - fix_path.patch        # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:
@@ -28,7 +28,7 @@ requirements:
   host:
     - python
     - cython >=0.29.29,<4.0.0a0
-    - libkrb5 {{ krb5 }}
+    - krb5 {{ krb5 }}
     - pip
     - setuptools >=40.6.0
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ test:
     - pip install k5test
     - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest --pyargs %SP_DIR%\gssapi\tests --ignore=%SP_DIR%\gssapi\tests\test_high_level.py --ignore=%SP_DIR%\gssapi\tests\test_raw.py -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest --pyargs %SP_DIR%\gssapi\tests --ignore=%SP_DIR%\\gssapi\\tests\\test_raw.py -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,18 +41,30 @@ requirements:
     # libkrb5 provides gssapi64.dll on Windows
     - libkrb5  # [win]
 
+# The tests fail because of the error "FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdb5_util'".
+# The real location of kdb5_util is $PREFIX/sbin not /usr/sbin but it's hardcoded in the k5test's source code,
+# see https://github.com/pythongssapi/k5test/blob/17512bd2137ffcdd1fdb7ff4210891ad34d27803/k5test/realm.py#L459
+{% set tests_to_skip = "_not_a_real_test" %}
+{% set tests_to_skip = tests_to_skip + " or CredsTestCase or MechsTestCase or NamesTestCase or SecurityContextTestCase or TestBaseUtilities" %}
+{% set tests_to_skip = tests_to_skip + " or test_basic_init_default_ctx or test_bad_channel_binding_raises_error or test_basic_accept_context or test_basic_accept_context_no_acceptor_creds or test_channel_bindings" %}
+{% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
+
 test:
   imports:
     - gssapi
     - gssapi.raw
     - gssapi.raw._enum_extensions
+  source_files:
+    - gssapi/tests
   requires:
     - pip
     - pytest
+    - parameterized
   commands:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
-    - pytest --pyargs gssapi -v
+    - pip install k5test
+    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
 {% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py" %}  # [win]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi\\tests\\test_high_level.py --ignore=gssapi\\tests\\test_raw.py" %}  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
     - pip
   commands:
     - pip check
-    - python -c "import gssapi; print(gssapi.__version__)"
+    - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
 {% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/gssapi/tests/test_high_level.py --ignore=%SP_DIR%/gssapi/tests/test_raw.py" %}  # [win]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%\\gssapi\\tests\\test_high_level.py --ignore=%SP_DIR%\\gssapi\\tests\\test_raw.py" %}  # [win]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - python
     - decorator
     # libkrb5 provides gssapi64.dll on Windows
-    - libkrb5  # [win]
+    - libkrb5 >=1.21.3,<1.22.0a0  # [win]
 
 # The tests fail because of the error "FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdb5_util'".
 # The real location of kdb5_util is $PREFIX/sbin not /usr/sbin but it's hardcoded in the k5test's source code,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,6 +58,7 @@ test:
     - gssapi.raw
     - gssapi.raw._enum_extensions
   source_files:
+    - gssapi/tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,9 @@ test:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
     - pip install k5test
-    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})"
+    # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
+    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})"  # [unix]
+    - pytest gssapi/tests -v -k "not ({{ tests_to_skip }})" --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - patch        # [unix]
     - msys2-patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - fix_path.patch        # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:
@@ -48,6 +48,7 @@ test:
     - gssapi.raw._enum_extensions
   requires:
     - pip
+    - pytest
   commands:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,8 +57,6 @@ test:
     - gssapi
     - gssapi.raw
     - gssapi.raw._enum_extensions
-  source_files:
-    - gssapi/tests
   requires:
     - pip
     - pytest
@@ -67,9 +65,9 @@ test:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
     - pip install k5test
-    - pytest -v gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
+    - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest --pyargs gssapi.tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest --pyargs %SP_DIR%\gssapi\tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
 {% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py" %}        # [win]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=gssapi/tests/test_high_level.py --ignore=gssapi/tests/test_raw.py" %}  # [win]
 
 test:
   imports:
@@ -69,7 +69,7 @@ test:
     - pip install k5test
     - pytest -v gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest --pyargs gssapi.tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest -v gssapi/tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gssapi" %}
-{% set version = "1.8.3" %}
+{% set version = "1.9.0" %}
 
 package:
   name: python-gssapi
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0
+  sha256: f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe
   patches:                  # [win or osx]
     - 0001-fix-setup.patch  # [osx]
     - fix_path.patch        # [win]
 
 build:
-  number: 2
+  number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,7 @@ test:
     - pip install k5test
     - pytest -v gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest -v gssapi/tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest --pyargs gssapi.tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ test:
   commands:
     - pip check
     - python -c "import importlib.metadata; assert importlib.metadata.version('gssapi') == '{{ version }}'"
+    - pytest --pyargs gssapi -v
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,6 @@ test:
     - gssapi.raw
     - gssapi.raw._enum_extensions
   source_files:
-    - gssapi/tests
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - fix_path.patch        # [win]
 
 build:
-  number: 2
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,8 @@ test:
     - gssapi
     - gssapi.raw
     - gssapi.raw._enum_extensions
+  source_files:
+    - gssapi/tests
   requires:
     - pip
     - pytest
@@ -64,7 +66,7 @@ test:
     - pip install k5test
     - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest --pyargs %SP_DIR%\gssapi\tests --ignore=%SP_DIR%\\gssapi\\tests\\test_raw.py -k "not ({{ tests_to_skip }})"  # [win]
+    - python -m pytest -v --ignore=%SP_DIR%/gssapi/tests/test_raw.py -k "not ({{ tests_to_skip }})" %SP_DIR%/gssapi/tests # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,9 @@ test:
     - pip install k5test
     - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - python -m pytest -v --ignore=%SP_DIR%/gssapi/tests/test_raw.py -k "not ({{ tests_to_skip }})" %SP_DIR%/gssapi/tests # [win]
+    # Remove test files
+    - del %SP_DIR%\\gssapi\\tests\\test_raw.py %SP_DIR%\\gssapi\\tests\\test_high_level.py
+    - python -m pytest -v -k "not ({{ tests_to_skip }})" %SP_DIR%/gssapi/tests # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - cython >=0.29.29,<4.0.0a0
     - libkrb5 {{ krb5 }}
     - pip
-    - setuptools
+    - setuptools >=40.6.0
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,14 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0
   patches:                  # [win or osx]
     - 0001-fix-setup.patch  # [osx]
     - fix_path.patch        # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
   script_env:
@@ -22,12 +22,12 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch     # [unix]
-    - m2-patch  # [win]
+    - patch        # [unix]
+    - msys2-patch  # [win]
   host:
     - python
     - cython >=0.29.29,<4.0.0a0
-    - krb5 1.20
+    - libkrb5 {{ krb5 }}
     - pip
     - setuptools
     - wheel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_basic_init_default_ctx or test_bad_channel_binding_raises_error or test_basic_accept_context or test_basic_accept_context_no_acceptor_creds or test_channel_bindings" %}
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
-{% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%\\gssapi\\tests\\test_high_level.py --ignore=%SP_DIR%\\gssapi\\tests\\test_raw.py" %}  # [win]
-
 test:
   imports:
     - gssapi
@@ -67,7 +64,7 @@ test:
     - pip install k5test
     - pytest -v ${SP_DIR}/gssapi/tests -k "not ({{ tests_to_skip }})"                        # [unix]
     # subprocess.CalledProcessError: Command 'krb5-config --prefix' returned non-zero exit status 1 on Windows.
-    - pytest --pyargs %SP_DIR%\gssapi\tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest --pyargs %SP_DIR%\gssapi\tests --ignore=%SP_DIR%\gssapi\tests\test_high_level.py --ignore=%SP_DIR%\gssapi\tests\test_raw.py -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/pythongssapi/python-gssapi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or TestWrapUnwrap" %}
 
 {% set tests_to_ignore = "" %}
-{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%\gssapi\tests\test_high_level.py --ignore=%SP_DIR%\gssapi\tests\test_raw.py" %}  # [win]
+{% set tests_to_ignore = tests_to_ignore + " --ignore=%SP_DIR%/gssapi/tests/test_high_level.py --ignore=%SP_DIR%/gssapi/tests/test_raw.py" %}  # [win]
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8640](https://anaconda.atlassian.net/browse/PKG-8640) 
- [Upstream repository](https://github.com/pythongssapi/python-gssapi)
- Issues:
  - https://github.com/ContinuumIO/anaconda-issues/issues/10772
  - https://github.com/conda-forge/krb5-feedstock/issues/48 

### Explanation of changes:

- Rebuild against libkrb5 1.21.3 on Unix platforms because libkrb5 1.21.3 (libraries and headers) fails on Windows with an error: "C2065: 'gss_key_value_set_desc': undeclared identifier", but krb5 (plus executables) works fine.
- Updated build number from 1 to 2
- Run pytest

### Notes:

- This rebuild addresses downstream dependency issues with krb5 1.21.3

[PKG-8640]: https://anaconda.atlassian.net/browse/PKG-8640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ