### PR TITLE
python-gssapi 1.10.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,8 @@
 setlocal EnableDelayedExpansion
 
 echo on
-
-set GSSAPI_LINKER_ARGS=-lgssapi64
-set GSSAPI_COMPILER_ARGS=-DMS_WIN64
 set GSSAPI_MAIN_LIB=%LIBRARY_BIN%\gssapi64.dll
+set "GSSAPI_LINKER_ARGS=gssapi64.lib krb5_64.lib"
+set GSSAPI_COMPILER_ARGS=-DMS_WIN64
 
 %PYTHON% -m pip install . -vv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,40 @@
 {% set name = "gssapi" %}
-{% set version = "1.8.3" %}
+{% set version = "1.10.1" %}
 
 package:
-  name: python-gssapi
+  name: python-{{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0
+  sha256: 7b54335dc9a3c55d564624fb6e25fcf9cfc0b80296a5c51e9c7cf9781c7d295b
   patches:                  # [win or osx]
     - 0001-fix-setup.patch  # [osx]
     - fix_path.patch        # [win]
 
 build:
-  number: 2
-  skip: true  # [py<37]
+  number: 0
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv  # [not win]
-  script_env:
-    - GSSAPI_SUPPORT_DETECT=false  # [build_platform != target_platform]
 
 requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - patch        # [unix]
-    - msys2-patch  # [win]
   host:
     - python
-    - cython >=0.29.29,<4.0.0a0
-    # libkrb5 1.21.3 (libraries and headers) fails on Windows with an error: "C2065: 'gss_key_value_set_desc': undeclared identifier"
-    # but krb5 (plus executables) works fine.
-    - krb5 {{ krb5 }}     # [win]
-    - libkrb5 {{ krb5 }}  # [unix]
     - pip
+    - cython 3.1.3
     - setuptools >=40.6.0
-    - wheel
+    # libkrb5 1.22.1 (libraries and headers) fails on Windows with an error: "C2065: 'gss_key_value_set_desc': undeclared identifier"
+    # but krb5 (plus executables) works fine.
+    - krb5 {{ krb5 }} # [win]
+    - libkrb5 {{ krb5 }} # [not win]
   run:
     - python
     - decorator
-    # libkrb5 provides gssapi64.dll on Windows
-    - libkrb5 >=1.21.3,<1.22.0a0  # [win]
+    # libkrb5 provides gssapi64.dll and krb5_64.lib on Windows
+    - libkrb5 >=1.22.1,<1.23.0a0 # [win]
 
 # The tests fail because of the error "FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdb5_util'".
 # The real location of kdb5_util is $PREFIX/sbin not /usr/sbin but it's hardcoded in the k5test's source code,
@@ -77,7 +72,7 @@ about:
   description: |
     Python-GSSAPI provides both low-level and high level wrappers around the GSSAPI C libraries.
     While it focuses on the Kerberos mechanism, it should also be useable with other GSSAPI mechanisms.
-  doc_url: https://pythongssapi.github.io/python-gssapi/
+  doc_url: https://pythongssapi.github.io/python-gssapi
   dev_url: https://github.com/pythongssapi/python-gssapi
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
   host:
     - python
     - pip
-    - cython 3.1.3
+    # Bumping cython to 3.1.4 for py314 compatibility
+    - cython 3.1.4
     - setuptools >=40.6.0
     # libkrb5 1.22.1 (libraries and headers) fails on Windows with an error: "C2065: 'gss_key_value_set_desc': undeclared identifier"
     # but krb5 (plus executables) works fine.


### PR DESCRIPTION
python-gssapi 1.10.1 

**Destination channel:** Defaults

### Links

- [PKG-11954]
- dev_url:        https://github.com/pythongssapi/python-gssapi/tree/v1.10.1
- conda_forge:    https://github.com/conda-forge/python-gssapi-feedstock
- pypi:           https://pypi.org/project/gssapi/1.10.1/
- pypi inspector: https://inspector.pypi.io/project/gssapi/1.10.1/

### Explanation of changes:

- new version number
- fix krb5 dep on Windows


[PKG-11954]: https://anaconda.atlassian.net/browse/PKG-11954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ